### PR TITLE
feat: filters unrelated rx noise, implements remote activity detection

### DIFF
--- a/components/home_io_control/cover.py
+++ b/components/home_io_control/cover.py
@@ -9,6 +9,7 @@ DEPENDENCIES = ["home_io_control"]
 
 CONF_DEVICE_ID = "io_device_id"
 CONF_INVERT_POSITION = "invert_position"
+CONF_LINKED_REMOTES = "linked_remotes"
 
 IOHomeCover = home_io_control_ns.class_("IOHomeCover", cover.Cover, cg.Component)
 
@@ -21,6 +22,7 @@ CONFIG_SCHEMA = (
             ),
             cv.Required(CONF_DEVICE_ID): validate_device_id,
             cv.Optional(CONF_INVERT_POSITION, default=False): cv.boolean,
+            cv.Optional(CONF_LINKED_REMOTES): cv.ensure_list(validate_device_id),
         }
     )
     .extend(cv.COMPONENT_SCHEMA)
@@ -35,3 +37,7 @@ async def to_code(config):
     cg.add(var.set_parent(parent))
     cg.add(var.set_device_id(config[CONF_DEVICE_ID]))
     cg.add(var.set_invert_position(config[CONF_INVERT_POSITION]))
+
+    if CONF_LINKED_REMOTES in config:
+        for remote_id in config[CONF_LINKED_REMOTES]:
+            cg.add(parent.add_linked_remote(remote_id, config[CONF_DEVICE_ID]))

--- a/components/home_io_control/hub_core.cpp
+++ b/components/home_io_control/hub_core.cpp
@@ -312,6 +312,13 @@ void IOHomeControlComponent::process_received_packet_(const RadioRxPacket &packe
 
   log_component_capture(this->radio_, "parse_ok", packet.data, packet.len, &frame);
 
+  // Exchange-internal frames (0x3C challenge request, 0x3D challenge response) are part of
+  // another controller's authenticated exchange. They carry no extractable status data for
+  // a passive observer — skip silently. They remain visible in io_capture (stage=parse_ok).
+  if (decisions::is_exchange_internal_command(frame.cmd)) {
+    return;
+  }
+
   if (frame.cmd == CMD_STATUS_UPDATE && memcmp(frame.dst, this->node_id_, NODE_ID_SIZE) == 0) {
     if (this->authenticate_request_(frame, packet.freq_hz)) {
       IoFrame resp;
@@ -334,6 +341,36 @@ void IOHomeControlComponent::process_received_packet_(const RadioRxPacket &packe
 
   if (frame.cmd == CMD_PRIVATE_RESP || frame.cmd == CMD_STATUS_UPDATE) {
     this->update_device_status_(frame);
+    return;
+  }
+
+  // Check if this frame targets one of our registered devices (e.g., a physical remote
+  // commanding a shutter we also control). If so, schedule a status poll after 2 seconds
+  // to pick up the resulting position change. The timeout name includes the device ID so
+  // repeated remote activity resets the timer rather than stacking redundant polls.
+  // The 2-second delay gives the device time to complete the exchange and start moving.
+  const std::string dst_id = node_id_to_string(frame.dst);
+  if (this->get_device(dst_id) != nullptr && memcmp(frame.src, this->node_id_, NODE_ID_SIZE) != 0) {
+    ESP_LOGD(TAG, "rx remote_activity src=%s dst=%s cmd=0x%02X, scheduling status poll",
+             node_id_to_string(frame.src).c_str(), dst_id.c_str(), frame.cmd);
+    const std::string timeout_name = "remote_poll_" + dst_id;
+    this->set_timeout(timeout_name.c_str(), 2000, [this, dst_id]() { this->queue_request_device_status(dst_id); });
+    return;
+  }
+
+  // Check if the frame source is a linked remote (e.g., a 1W remote whose destination address
+  // differs from the device's 2W ID). When a linked remote is active, schedule status polls
+  // for all devices it controls.
+  const std::string src_id = node_id_to_string(frame.src);
+  auto remote_it = this->linked_remotes_.find(src_id);
+  if (remote_it != this->linked_remotes_.end()) {
+    for (const auto &device_id : remote_it->second) {
+      ESP_LOGD(TAG, "rx remote_activity (linked) remote=%s device=%s cmd=0x%02X, scheduling status poll",
+               src_id.c_str(), device_id.c_str(), frame.cmd);
+      const std::string timeout_name = "remote_poll_" + device_id;
+      this->set_timeout(timeout_name.c_str(), 2000,
+                        [this, device_id]() { this->queue_request_device_status(device_id); });
+    }
     return;
   }
 
@@ -594,6 +631,14 @@ void IOHomeControlComponent::dump_config() {
                   device_type_name(device.type), static_cast<uint8_t>(device.type),
                   device_capability_class_name(device.type), device_operation_profile_name(device.type), device.subtype,
                   YESNO(device.inverted));
+  }
+  if (!this->linked_remotes_.empty()) {
+    ESP_LOGCONFIG(TAG, "  Linked Remotes: %zu", this->linked_remotes_.size());
+    for (const auto &pair : this->linked_remotes_) {
+      for (const auto &device_id : pair.second) {
+        ESP_LOGCONFIG(TAG, "    - remote %s -> device %s", pair.first.c_str(), device_id.c_str());
+      }
+    }
   }
 
   if (this->radio_ != nullptr)

--- a/components/home_io_control/hub_core.h
+++ b/components/home_io_control/hub_core.h
@@ -75,6 +75,13 @@ class IOHomeControlComponent : public Component,
   void set_radio_type(const std::string &type) { this->radio_type_ = type; }
   void set_tcxo_voltage(uint8_t voltage) { this->tcxo_voltage_ = voltage; }
 
+  /// Declare that a remote (identified by its node ID) controls a registered device.
+  /// When activity from this remote is overheard, a status poll is scheduled for the device.
+  /// This is needed for 1W remotes whose destination address differs from the device's 2W ID.
+  void add_linked_remote(const std::string &remote_id, const std::string &device_id) {
+    this->linked_remotes_[remote_id].push_back(device_id);
+  }
+
   // --- Device management (called by cover platform) ---
   /// Add a device to the registry (called by platform entities during setup).
   virtual void add_device(const std::string &device_id);
@@ -226,6 +233,9 @@ class IOHomeControlComponent : public Component,
   std::map<std::string, IoDevice> devices_;
   std::vector<DeviceUpdateCallback> callbacks_;
   std::deque<PendingOperation> pending_operations_;
+  /// Maps remote node IDs to lists of device IDs they control.
+  /// Used to trigger status polls when 1W remote activity is overheard.
+  std::map<std::string, std::vector<std::string>> linked_remotes_;
 };
 
 // ============================================================================

--- a/components/home_io_control/hub_decisions.h
+++ b/components/home_io_control/hub_decisions.h
@@ -42,6 +42,14 @@ enum class PairingKeyChallengeDisposition : uint8_t {
   ACCEPT,  ///< Valid 0x3C challenge from target device.
 };
 
+// == Passive RX filtering ==
+
+/// Returns true for commands that are internal to an exchange handshake and carry
+/// no useful information for a passive observer (challenge request/response).
+/// These frames appear in every authenticated exchange between other controllers and
+/// devices on the network, but contain only ephemeral cryptographic data.
+inline bool is_exchange_internal_command(uint8_t cmd) { return cmd == CMD_CHALLENGE_REQ || cmd == CMD_CHALLENGE_RESP; }
+
 // == Utility: endpoint matching ==
 
 /// Check if two frames have identical src/dst node IDs.

--- a/components/home_io_control/light.py
+++ b/components/home_io_control/light.py
@@ -8,6 +8,7 @@ from . import home_io_control_ns, IOHomeControlComponent, CONF_HOME_IO_CONTROL_I
 DEPENDENCIES = ["home_io_control"]
 
 CONF_DEVICE_ID = "io_device_id"
+CONF_LINKED_REMOTES = "linked_remotes"
 
 IOHomeLight = home_io_control_ns.class_("IOHomeLight", light.LightOutput, cg.Component)
 
@@ -21,6 +22,7 @@ CONFIG_SCHEMA = (
                 IOHomeControlComponent
             ),
             cv.Required(CONF_DEVICE_ID): validate_device_id,
+            cv.Optional(CONF_LINKED_REMOTES): cv.ensure_list(validate_device_id),
         }
     )
     .extend(cv.COMPONENT_SCHEMA)
@@ -35,3 +37,7 @@ async def to_code(config):
     parent = await cg.get_variable(config[CONF_HOME_IO_CONTROL_ID])
     cg.add(var.set_parent(parent))
     cg.add(var.set_device_id(config[CONF_DEVICE_ID]))
+
+    if CONF_LINKED_REMOTES in config:
+        for remote_id in config[CONF_LINKED_REMOTES]:
+            cg.add(parent.add_linked_remote(remote_id, config[CONF_DEVICE_ID]))

--- a/components/home_io_control/switch.py
+++ b/components/home_io_control/switch.py
@@ -8,6 +8,7 @@ from . import home_io_control_ns, IOHomeControlComponent, CONF_HOME_IO_CONTROL_I
 DEPENDENCIES = ["home_io_control"]
 
 CONF_DEVICE_ID = "io_device_id"
+CONF_LINKED_REMOTES = "linked_remotes"
 
 IOHomeSwitch = home_io_control_ns.class_("IOHomeSwitch", switch.Switch, cg.Component)
 
@@ -21,6 +22,7 @@ CONFIG_SCHEMA = (
                 IOHomeControlComponent
             ),
             cv.Required(CONF_DEVICE_ID): validate_device_id,
+            cv.Optional(CONF_LINKED_REMOTES): cv.ensure_list(validate_device_id),
         }
     )
     .extend(cv.COMPONENT_SCHEMA)
@@ -37,3 +39,7 @@ async def to_code(config):
     # provides the validated IO-homecontrol device ID.
     cg.add(var.set_parent(parent))
     cg.add(var.set_device_id(config[CONF_DEVICE_ID]))
+
+    if CONF_LINKED_REMOTES in config:
+        for remote_id in config[CONF_LINKED_REMOTES]:
+            cg.add(parent.add_linked_remote(remote_id, config[CONF_DEVICE_ID]))

--- a/config/heltec-wifi-lora-32-v2.yaml
+++ b/config/heltec-wifi-lora-32-v2.yaml
@@ -168,6 +168,8 @@ cover:
     device_class: awning
     io_device_id: !secret example_io_device_id
     invert_position: true
+    linked_remotes:
+      - !secret example_io_device_linked_remote_id
     on_opening:
       - script.execute:
           id: oled_show_state

--- a/config/heltec-wifi-lora-32-v3.yaml
+++ b/config/heltec-wifi-lora-32-v3.yaml
@@ -174,6 +174,8 @@ cover:
     device_class: awning
     io_device_id: !secret example_io_device_id
     invert_position: true
+    linked_remotes:
+      - !secret example_io_device_linked_remote_id
     on_opening:
       - script.execute:
           id: oled_show_state

--- a/docs/home_io_control.md
+++ b/docs/home_io_control.md
@@ -102,6 +102,8 @@ cover:
     device_class: awning
     io_device_id: "FEEB1E"
     invert_position: true
+    linked_remotes:
+      - "ABCDEF"
 ```
 
 Configuration variables:
@@ -109,6 +111,7 @@ Configuration variables:
 - `home_io_control_id` (Optional): Reference to the `home_io_control` hub to use.
 - `io_device_id` (Required): 3-byte IO-homecontrol device ID as exactly 6 hexadecimal characters.
 - `invert_position` (Optional, default: `false`): Swap the open/close position mapping. This is commonly needed for horizontal awnings.
+- `linked_remotes` (Optional): List of remote node IDs (6 hex characters each) that control this device. When activity from a linked remote is overheard on the radio, the controller automatically polls the device for fresh status 2 seconds later. This is particularly useful for 1W (one-way) remotes whose radio address differs from the device's 2W ID.
 - All standard options from the ESPHome cover base schema also apply, including `id`, `name`, `device_class`, `icon`, entity metadata, MQTT options, and cover automations such as `on_opening`, `on_closing`, and `on_idle`.
 
 Notes:
@@ -132,6 +135,7 @@ Configuration variables:
 
 - `home_io_control_id` (Optional): Reference to the `home_io_control` hub to use.
 - `io_device_id` (Required): 3-byte IO-homecontrol device ID as exactly 6 hexadecimal characters.
+- `linked_remotes` (Optional): List of remote node IDs (6 hex characters each) that control this device. See the cover platform for details.
 - All standard options from the ESPHome light schema also apply.
 
 Notes:
@@ -156,6 +160,7 @@ Configuration variables:
 
 - `home_io_control_id` (Optional): Reference to the `home_io_control` hub to use.
 - `io_device_id` (Required): 3-byte IO-homecontrol device ID as exactly 6 hexadecimal characters.
+- `linked_remotes` (Optional): List of remote node IDs (6 hex characters each) that control this device. See the cover platform for details.
 - All standard options from the ESPHome switch schema also apply.
 
 Notes:

--- a/tests/hub_core_test.cpp
+++ b/tests/hub_core_test.cpp
@@ -234,3 +234,264 @@ TEST(HubCore, LBT_JustBelowThreshold_TransmitsImmediately) {
   EXPECT_TRUE(comp.transmit_frame_(frame, FREQ_CH2, LONG_PREAMBLE));
   EXPECT_EQ(radio.get_send_count(), 1);
 }
+
+// ============================================================================
+// Exchange-internal filtering tests (Issue #3)
+// ============================================================================
+
+namespace {
+
+/// Helper to set up a component with a registered device for RX tests.
+class RxTestableComponent : public IOHomeControlComponent {
+ public:
+  using IOHomeControlComponent::process_received_packet_;
+};
+
+/// Build a RadioRxPacket from a constructed IoFrame.
+RadioRxPacket make_rx_packet(const IoFrame &frame) {
+  RadioRxPacket pkt{};
+  pkt.len = serialize(frame, pkt.data, sizeof(pkt.data));
+  pkt.freq_hz = FREQ_CH2;
+  return pkt;
+}
+
+/// Create a minimal component with one registered device and a mock radio.
+void setup_rx_test_component(RxTestableComponent &comp, MockRadio &radio) {
+  comp.node_id_[0] = 0xC0;
+  comp.node_id_[1] = 0xFF;
+  comp.node_id_[2] = 0xEE;
+  static const uint8_t key[] = {0xD1, 0x74, 0x34, 0x93, 0xFA, 0x94, 0x38, 0x45,
+                                0xAC, 0x43, 0x50, 0xEE, 0xFF, 0x34, 0x29, 0x34};
+  std::memcpy(comp.system_key_, key, AES_KEY_SIZE);
+  comp.initialized_ = true;
+  comp.radio_ = &radio;
+  comp.add_device("054E17");
+}
+
+}  // namespace
+
+TEST(HubCore, FilterExchangeInternal_ChallengeRequest) {
+  RxTestableComponent comp;
+  MockRadio radio;
+  setup_rx_test_component(comp, radio);
+
+  // Construct a 0x3C challenge request frame (src=device, dst=some remote)
+  IoFrame f{};
+  init_frame(f, true, false, false, false);
+  uint8_t src[3] = {0x05, 0x4E, 0x17};  // our registered device
+  uint8_t dst[3] = {0x43, 0x44, 0xE3};  // some remote
+  set_src(f, src);
+  set_dst(f, dst);
+  uint8_t challenge[6] = {0x0F, 0x76, 0x11, 0x69, 0x64, 0x9E};
+  set_cmd(f, CMD_CHALLENGE_REQ, challenge, 6);
+
+  RadioRxPacket pkt = make_rx_packet(f);
+  ASSERT_GT(pkt.len, 0) << "frame should serialize";
+
+  comp.process_received_packet_(pkt);
+
+  // Should be silently filtered — no pending operations, no timeout
+  EXPECT_TRUE(comp.pending_operations_.empty()) << "0x3C should not trigger any operation";
+  EXPECT_TRUE(comp.last_timeout_name_.empty()) << "0x3C should not schedule a timeout";
+}
+
+TEST(HubCore, FilterExchangeInternal_ChallengeResponse) {
+  RxTestableComponent comp;
+  MockRadio radio;
+  setup_rx_test_component(comp, radio);
+
+  // Construct a 0x3D challenge response frame (src=remote, dst=device)
+  IoFrame f{};
+  init_frame(f, true, false, false, false);
+  uint8_t src[3] = {0x43, 0x44, 0xE3};  // some remote
+  uint8_t dst[3] = {0x05, 0x4E, 0x17};  // our registered device
+  set_src(f, src);
+  set_dst(f, dst);
+  uint8_t hmac[6] = {0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF};
+  set_cmd(f, CMD_CHALLENGE_RESP, hmac, 6);
+
+  RadioRxPacket pkt = make_rx_packet(f);
+  ASSERT_GT(pkt.len, 0) << "frame should serialize";
+
+  comp.process_received_packet_(pkt);
+
+  // Should be silently filtered — no pending operations, no timeout
+  EXPECT_TRUE(comp.pending_operations_.empty()) << "0x3D should not trigger any operation";
+  EXPECT_TRUE(comp.last_timeout_name_.empty()) << "0x3D should not schedule a timeout";
+}
+
+// ============================================================================
+// Remote activity detection tests (Issue #3)
+// ============================================================================
+
+TEST(HubCore, RemoteActivity_TriggersDelayedPoll) {
+  RxTestableComponent comp;
+  MockRadio radio;
+  setup_rx_test_component(comp, radio);
+
+  // Construct a 0x00 execute command from a remote to our registered device
+  IoFrame f{};
+  init_frame(f, true, true, false, false);  // 2W, start frame
+  uint8_t src[3] = {0x43, 0x44, 0xE3};      // some remote
+  uint8_t dst[3] = {0x05, 0x4E, 0x17};      // our registered device
+  set_src(f, src);
+  set_dst(f, dst);
+  uint8_t exec_data[3] = {0xC8, 0x00, 0x00};
+  set_cmd(f, CMD_EXECUTE, exec_data, 3);
+
+  RadioRxPacket pkt = make_rx_packet(f);
+  ASSERT_GT(pkt.len, 0) << "frame should serialize";
+
+  comp.process_received_packet_(pkt);
+
+  // Should schedule a 2-second timeout for the device
+  EXPECT_EQ(comp.last_timeout_ms_, 2000u) << "should schedule 2s timeout";
+  EXPECT_NE(comp.last_timeout_name_.find("054E17"), std::string::npos) << "timeout name should contain device ID";
+  ASSERT_TRUE(comp.last_timeout_callback_) << "callback should be set";
+
+  // Invoke the callback — should queue a status request
+  comp.last_timeout_callback_();
+  ASSERT_EQ(comp.pending_operations_.size(), 1u) << "callback should queue one operation";
+  EXPECT_EQ(comp.pending_operations_.front().type, IOHomeControlComponent::PendingOperationType::REQUEST_STATUS);
+  EXPECT_EQ(comp.pending_operations_.front().device_id, "054E17");
+}
+
+TEST(HubCore, RemoteActivity_UnregisteredDevice_NoTrigger) {
+  RxTestableComponent comp;
+  MockRadio radio;
+  setup_rx_test_component(comp, radio);
+
+  // Frame addressed to an unregistered device
+  IoFrame f{};
+  init_frame(f, true, true, false, false);
+  uint8_t src[3] = {0x43, 0x44, 0xE3};
+  uint8_t dst[3] = {0xAA, 0xBB, 0xCC};  // not registered
+  set_src(f, src);
+  set_dst(f, dst);
+  set_cmd(f, CMD_EXECUTE);
+
+  RadioRxPacket pkt = make_rx_packet(f);
+  ASSERT_GT(pkt.len, 0) << "frame should serialize";
+
+  comp.process_received_packet_(pkt);
+
+  // Should NOT schedule a timeout — falls through to unhandled_cmd
+  EXPECT_TRUE(comp.last_timeout_name_.empty()) << "unregistered dst should not trigger timeout";
+  EXPECT_TRUE(comp.pending_operations_.empty()) << "should not queue any operation";
+}
+
+TEST(HubCore, RemoteActivity_OwnEcho_NoTrigger) {
+  RxTestableComponent comp;
+  MockRadio radio;
+  setup_rx_test_component(comp, radio);
+
+  // Frame where src is our own node ID (echo of our own TX)
+  IoFrame f{};
+  init_frame(f, true, true, false, false);
+  uint8_t src[3] = {0xC0, 0xFF, 0xEE};  // our node ID
+  uint8_t dst[3] = {0x05, 0x4E, 0x17};  // our registered device
+  set_src(f, src);
+  set_dst(f, dst);
+  set_cmd(f, CMD_PRIVATE);
+
+  RadioRxPacket pkt = make_rx_packet(f);
+  ASSERT_GT(pkt.len, 0) << "frame should serialize";
+
+  comp.process_received_packet_(pkt);
+
+  // Should NOT schedule a timeout — it's our own frame
+  EXPECT_TRUE(comp.last_timeout_name_.empty()) << "own echo should not trigger timeout";
+  EXPECT_TRUE(comp.pending_operations_.empty()) << "should not queue any operation";
+}
+
+TEST(HubCore, RemoteActivity_LinkedRemote_TriggersDelayedPoll) {
+  RxTestableComponent comp;
+  MockRadio radio;
+  setup_rx_test_component(comp, radio);
+
+  // Link remote 9D6085 to device 054E17
+  comp.add_linked_remote("9D6085", "054E17");
+
+  // Construct a 1W frame from the linked remote to a different address (1W addressing)
+  IoFrame f{};
+  init_frame(f, false, true, true, false);  // 1W mode
+  uint8_t src[3] = {0x9D, 0x60, 0x85};      // linked remote
+  uint8_t dst[3] = {0x00, 0x01, 0xBF};      // 1W device address (different from 2W ID)
+  set_src(f, src);
+  set_dst(f, dst);
+  uint8_t exec_data[3] = {0x00, 0x00, 0x00};
+  set_cmd(f, CMD_EXECUTE, exec_data, 3);
+
+  RadioRxPacket pkt = make_rx_packet(f);
+  ASSERT_GT(pkt.len, 0) << "frame should serialize";
+
+  comp.process_received_packet_(pkt);
+
+  // Should schedule a 2-second timeout for the linked device
+  EXPECT_EQ(comp.last_timeout_ms_, 2000u) << "should schedule 2s timeout";
+  EXPECT_NE(comp.last_timeout_name_.find("054E17"), std::string::npos)
+      << "timeout name should contain linked device ID";
+  ASSERT_TRUE(comp.last_timeout_callback_) << "callback should be set";
+
+  // Invoke the callback — should queue a status request
+  comp.last_timeout_callback_();
+  ASSERT_EQ(comp.pending_operations_.size(), 1u) << "callback should queue one operation";
+  EXPECT_EQ(comp.pending_operations_.front().type, IOHomeControlComponent::PendingOperationType::REQUEST_STATUS);
+  EXPECT_EQ(comp.pending_operations_.front().device_id, "054E17");
+}
+
+TEST(HubCore, LinkedRemotes_MultipleRemotesOneDevice) {
+  RxTestableComponent comp;
+  MockRadio radio;
+  setup_rx_test_component(comp, radio);
+
+  // Link two remotes to the same device
+  comp.add_linked_remote("AABBCC", "054E17");
+  comp.add_linked_remote("DDEEFF", "054E17");
+
+  // Frame from second remote
+  IoFrame f{};
+  init_frame(f, false, true, true, false);
+  uint8_t src[3] = {0xDD, 0xEE, 0xFF};
+  uint8_t dst[3] = {0x00, 0x01, 0xBF};
+  set_src(f, src);
+  set_dst(f, dst);
+  set_cmd(f, CMD_EXECUTE);
+
+  RadioRxPacket pkt = make_rx_packet(f);
+  ASSERT_GT(pkt.len, 0) << "frame should serialize";
+
+  comp.process_received_packet_(pkt);
+
+  EXPECT_EQ(comp.last_timeout_ms_, 2000u) << "should schedule 2s timeout";
+  EXPECT_NE(comp.last_timeout_name_.find("054E17"), std::string::npos) << "timeout name should contain device ID";
+}
+
+TEST(HubCore, LinkedRemotes_OneRemoteMultipleDevices) {
+  RxTestableComponent comp;
+  MockRadio radio;
+  setup_rx_test_component(comp, radio);
+  comp.add_device("415684");  // second device
+
+  // One remote controls two devices
+  comp.add_linked_remote("AABBCC", "054E17");
+  comp.add_linked_remote("AABBCC", "415684");
+
+  // Frame from the shared remote
+  IoFrame f{};
+  init_frame(f, false, true, true, false);
+  uint8_t src[3] = {0xAA, 0xBB, 0xCC};
+  uint8_t dst[3] = {0x00, 0x01, 0xBF};
+  set_src(f, src);
+  set_dst(f, dst);
+  set_cmd(f, CMD_EXECUTE);
+
+  RadioRxPacket pkt = make_rx_packet(f);
+  ASSERT_GT(pkt.len, 0) << "frame should serialize";
+
+  comp.process_received_packet_(pkt);
+
+  // The last set_timeout call wins in our stub, but both should have been called.
+  // Verify at least one timeout was scheduled with 2s delay.
+  EXPECT_EQ(comp.last_timeout_ms_, 2000u) << "should schedule 2s timeout";
+}

--- a/tests/include/esphome/core/component.h
+++ b/tests/include/esphome/core/component.h
@@ -15,10 +15,15 @@ class Component {
   virtual float get_setup_priority() const { return 0; }
 
   void set_timeout(const char *name, uint32_t timeout, std::function<void()> &&f) {
-    (void) name;
-    (void) timeout;
-    (void) f;
+    last_timeout_name_ = name ? name : "";
+    last_timeout_ms_ = timeout;
+    last_timeout_callback_ = std::move(f);
   }
+
+  // Test helpers for verifying set_timeout calls
+  std::function<void()> last_timeout_callback_;
+  std::string last_timeout_name_;
+  uint32_t last_timeout_ms_{0};
 
   void mark_failed() { this->failed_ = true; }
   bool is_failed() const { return this->failed_; }


### PR DESCRIPTION
0x3C and 0x3D frames are now silently skipped in the passive receive path. They still appear in the io_capture log (stage=parse_ok) for deep debugging, but they no longer produce the noisy rx issue=unhandled_cmd lines.

Additionally the component now detects when a physical remote is controlling one of your registered devices and automatically polls for fresh status 2 seconds later. This works in two ways:

Destination-based: If we overhear a frame addressed directly to a registered device (from any third-party source), we schedule a status poll. This works for 2W remotes that address the device by its 2W ID.
Source-based (linked remotes): For 1W remotes (which use a different destination address than the device's 2W ID), you can configure linked_remotes on any cover, light, or switch entity.